### PR TITLE
ENH Command line flag for dynamics of linear trajectories

### DIFF
--- a/src/sdanalysis/main.py
+++ b/src/sdanalysis/main.py
@@ -85,10 +85,19 @@ def sdanalysis(ctx, **kwargs) -> None:
 @sdanalysis.command()
 @click.pass_obj
 @click.option("--mol-relaxations", type=click.Path(exists=True, dir_okay=False))
-@click.argument("infile", type=click.Path(file_okay=True, dir_okay=False))
-def comp_dynamics(sim_params: SimulationParams, mol_relaxations, infile) -> None:
+@click.option(
+    "--linear-dynamics",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Flag to specify the configurations in a trajectory have linear steps between them.",
+)
+@click.argument("infile", type=click.Path(exists=True, file_okay=True, dir_okay=False))
+def comp_dynamics(sim_params, mol_relaxations, linear_dynamics, infile) -> None:
     """Compute dynamic properties."""
     sim_params.infile = infile
+    if linear_dynamics:
+        sim_params.linear_steps = None
     if mol_relaxations is not None:
         compute_relaxations = yaml.parse(mol_relaxations)
     else:

--- a/src/sdanalysis/util.py
+++ b/src/sdanalysis/util.py
@@ -8,7 +8,6 @@
 
 """A collection of utility functions."""
 
-from collections import namedtuple
 from pathlib import Path
 from typing import NamedTuple, Optional
 

--- a/test/read_test.py
+++ b/test/read_test.py
@@ -50,6 +50,14 @@ def test_linear_sequence(sim_params):
             assert index == [0]
 
 
+def test_linear_sequence_keyframes(sim_params):
+    with sim_params.temp_context(linear_steps=None, gen_steps=10):
+        for index, frame in read.process_gsd(sim_params):
+            index_len = int(np.floor(frame.timestep / 10) + 1)
+            assert len(index) == index_len
+            assert index == list(range(index_len))
+
+
 def test_writeCache():
     with tempfile.TemporaryDirectory() as dst:
         my_list = read.WriteCache(Path(dst) / "test1.h5")


### PR DESCRIPTION
The default method of computing the dynamics quantities is using the
exponential step method which I have been using for the output files. This
adds support for iterating through a linear series of configurations. This
performs no checks that the user is doing something sensible.