### PR TITLE
Set simulation parameters from the input filename

### DIFF
--- a/src/sdanalysis/main.py
+++ b/src/sdanalysis/main.py
@@ -21,6 +21,7 @@ from .molecules import Dimer, Disc, Sphere, Trimer
 from .params import SimulationParams
 from .read import process_file
 from .relaxation import compute_relaxation_value, translate_relaxation
+from .util import set_filename_vars
 from .version import __version__
 
 logger = logging.getLogger(__name__)

--- a/src/sdanalysis/main.py
+++ b/src/sdanalysis/main.py
@@ -112,6 +112,8 @@ def comp_dynamics(sim_params, output, mol_relaxations, linear_dynamics, infile) 
         compute_relaxations = yaml.parse(mol_relaxations)
     else:
         compute_relaxations = None
+
+    set_filename_vars(sim_params.infile, sim_params)
     process_file(sim_params, compute_relaxations)
 
 

--- a/src/sdanalysis/read.py
+++ b/src/sdanalysis/read.py
@@ -252,7 +252,7 @@ def process_file(
     mol = str(sim_params.molecule)
     press = sim_params.pressure
     temp = sim_params.temperature
-    group_name = f"{mol}-P{press:.2f}-T{temp:.2f}"
+    group_name = f"{mol}_P{press:.2f}_T{temp:.2f}"
 
     if sim_params.outfile is not None:
         dataframes = WriteCache(sim_params.outfile, group_name, to_append=True)
@@ -266,7 +266,6 @@ def process_file(
         file_iterator: FileIterator = process_gsd(sim_params)
     elif sim_params.infile.suffix == ".lammpstrj":
         file_iterator = process_lammpstrj(sim_params)
-    variables = get_filename_vars(sim_params.infile)
     for indexes, frame in file_iterator:
         for index in indexes:
             try:
@@ -305,16 +304,16 @@ def process_file(
             myrelax.add(frame.timestep, frame.position, frame.orientation)
             logger.debug("Series: %s", index)
             dynamics_series["start_index"] = index
-            dynamics_series["temperature"] = variables.temperature
-            dynamics_series["pressure"] = variables.pressure
+            dynamics_series["temperature"] = sim_params.temperature
+            dynamics_series["pressure"] = sim_params.pressure
             dataframes.append(dynamics_series)
     if sim_params.outfile is not None:
         dataframes.flush()
         mol_relax = pandas.concat(
             (relax.summary() for relax in relaxframes), keys=range(len(relaxframes))
         )
-        mol_relax["temperature"] = variables.temperature
-        mol_relax["pressure"] = variables.pressure
+        mol_relax["temperature"] = sim_params.temperature
+        mol_relax["pressure"] = sim_params.pressure
         mol_relax.to_hdf(
             sim_params.outfile, "molecular_relaxations", format="table", to_append=True
         )

--- a/src/sdanalysis/read.py
+++ b/src/sdanalysis/read.py
@@ -23,7 +23,6 @@ from .frame import Frame, HoomdFrame, LammpsFrame
 from .molecules import Trimer
 from .params import SimulationParams
 from .StepSize import GenerateStepSeries
-from .util import get_filename_vars
 
 logger = logging.getLogger(__name__)
 

--- a/src/sdanalysis/util.py
+++ b/src/sdanalysis/util.py
@@ -9,12 +9,17 @@
 """A collection of utility functions."""
 
 from pathlib import Path
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, Union
 
 import numpy as np
 
 from sdanalysis.math_util import rotate_vectors
 from sdanalysis.molecules import Molecule
+from .params import SimulationParams
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 
 class variables(NamedTuple):
@@ -26,6 +31,8 @@ class variables(NamedTuple):
 def get_filename_vars(fname: Path):
     fname = Path(fname)
     flist = fname.stem.split("-")
+    logger.debug("Split Filename: %s", str(flist))
+
     if len(flist) < 4:
         return variables(None, None, None)
 
@@ -47,6 +54,14 @@ def get_filename_vars(fname: Path):
         crys = None
 
     return variables(temp, pressure, crys)
+
+
+def set_filename_vars(fname: Union[str, Path], sim_params: SimulationParams) -> None:
+    """Set the variables of the simulations params according to the filename."""
+    var = get_filename_vars(fname)
+    sim_params.temperature = float(var.temperature)
+    sim_params.pressure = float(var.pressure)
+    sim_params.crystal = var.crystal
 
 
 def orientation2positions(

--- a/src/sdanalysis/util.py
+++ b/src/sdanalysis/util.py
@@ -8,18 +8,20 @@
 
 """A collection of utility functions."""
 
+import logging
 from pathlib import Path
 from typing import NamedTuple, Optional, Union
 
 import numpy as np
-
 from sdanalysis.math_util import rotate_vectors
 from sdanalysis.molecules import Molecule
+
 from .params import SimulationParams
-import logging
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
+PathLike = Union[str, Path]
 
 
 class variables(NamedTuple):
@@ -28,7 +30,7 @@ class variables(NamedTuple):
     crystal: Optional[str]
 
 
-def get_filename_vars(fname: Path):
+def get_filename_vars(fname: PathLike):
     fname = Path(fname)
     flist = fname.stem.split("-")
     logger.debug("Split Filename: %s", str(flist))
@@ -56,12 +58,12 @@ def get_filename_vars(fname: Path):
     return variables(temp, pressure, crys)
 
 
-def set_filename_vars(fname: Union[str, Path], sim_params: SimulationParams) -> None:
+def set_filename_vars(fname: PathLike, sim_params: SimulationParams) -> None:
     """Set the variables of the simulations params according to the filename."""
     var = get_filename_vars(fname)
     sim_params.temperature = float(var.temperature)
     sim_params.pressure = float(var.pressure)
-    sim_params.crystal = var.crystal
+    sim_params.space_group = var.crystal
 
 
 def orientation2positions(

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -11,7 +11,9 @@
 """
 import numpy as np
 
-from sdanalysis.util import orientation2positions
+from sdanalysis.util import orientation2positions, set_filename_vars, get_filename_vars
+import pytest
+from sdanalysis.params import SimulationParams
 
 
 def test_orientation2positions(mol):
@@ -60,3 +62,29 @@ def test_orientation2positions_moved_rot_multiple(mol):
         position, (mol.num_particles, 1)
     )
     assert np.allclose(rotated_pos, moved_pos)
+
+
+@pytest.mark.parametrize("press", ["0.00", "0.50", "1.00", "13.50"])
+@pytest.mark.parametrize("temp", ["0.00", "0.10", "1.50", "2.00"])
+@pytest.mark.parametrize("mol", ["Trimer"])
+def test_get_filename_vars(mol, press, temp):
+    fname = f"trajectory-{mol}-P{press}-T{temp}.gsd"
+    var = get_filename_vars(fname)
+    assert isinstance(var.temperature, str)
+    assert var.temperature == temp
+    assert isinstance(var.pressure, str)
+    assert var.pressure == press
+
+
+@pytest.mark.parametrize("press", ["0.00", "0.50", "1.00", "13.50"])
+@pytest.mark.parametrize("temp", ["0.00", "0.10", "1.50", "2.00"])
+@pytest.mark.parametrize("mol", ["Trimer"])
+def test_set_filename_vars(mol, press, temp):
+    fname = f"trajectory-{mol}-P{press}-T{temp}.gsd"
+    sim_params = SimulationParams()
+
+    set_filename_vars(fname, sim_params)
+    assert isinstance(sim_params.temperature, float)
+    assert sim_params.temperature == float(temp)
+    assert isinstance(sim_params.pressure, float)
+    assert sim_params.pressure == float(press)


### PR DESCRIPTION
This sets the values of the SimulationParams object when running the comp_dynamics from
that of the filename. This ensures consistency throughout the analysis and also enables
better use of these quantities.

Fixes #37
Fixes #38