### PR TITLE
ENH Compute dynamics for a list of files

### DIFF
--- a/src/sdanalysis/read.py
+++ b/src/sdanalysis/read.py
@@ -8,7 +8,7 @@
 """Read input files and compute dynamic and thermodynamic quantities."""
 
 import logging
-import time
+import multiprocessing
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -16,13 +16,13 @@ import attr
 import gsd.hoomd
 import numpy as np
 import pandas
-import tables
 
 from .dynamics import dynamics, relaxations
 from .frame import Frame, HoomdFrame, LammpsFrame
 from .molecules import Trimer
 from .params import SimulationParams
 from .StepSize import GenerateStepSeries
+from .util import set_filename_vars
 
 logger = logging.getLogger(__name__)
 
@@ -177,14 +177,22 @@ def parse_lammpstrj(filename: Path) -> Iterator[LammpsFrame]:
 @attr.s(auto_attribs=True)
 class WriteCache:
     _filename: Optional[Path] = None
-    group_name: str = "dynamics"
+    group: str = "dynamics"
     cache_multiplier: int = 1
     to_append: bool = False
+    queue: Optional[multiprocessing.Queue] = None
 
     _cache: List[Any] = attr.ib(default=attr.Factory(list), init=False)
     _cache_default: int = attr.ib(default=8192, init=False)
     _emptied_count: int = attr.ib(default=0, init=False)
-    _retries: int = attr.ib(default=10, init=False)
+
+    def __attr_post_init__(self):
+        if self.filename and self.queue:
+            raise ValueError(
+                "Can only output to a single source, either filename or queue"
+            )
+        if self.group is None:
+            raise ValueError("Group can not be None.")
 
     @property
     def _cache_size(self) -> int:
@@ -197,30 +205,23 @@ class WriteCache:
             self._emptied_count += 1
         self._cache.append(item)
 
+    def _flush_queue(self, df) -> None:
+        assert self.queue is not None
+        assert df is not None
+        self.queue.put((self.group, df))
+
+    def _flush_file(self, df) -> None:
+        assert self.filename is not None
+        assert self.group is not None
+        df.to_hdf(self.filename, self.group, format="table", append=self.to_append)
+        self.to_append = True
+
     def flush(self) -> None:
         df = self.to_dataframe()
-        # Retry file writing if it fails
-        for _ in range(self._retries):
-            try:
-                df.to_hdf(
-                    self.filename,
-                    f"dynamics/{self.group_name}",
-                    format="table",
-                    append=self.to_append,
-                )
-            except tables.exceptions.HDF5ExtError:
-                time.sleep(np.random.random())
-            else:
-                break
+        if self.queue:
+            self._flush_queue(df)
         else:
-            # This time with no exception handling so the exception is raised
-            df.to_hdf(
-                self.filename,
-                f"dynamics/{self.group_name}",
-                format="table",
-                append=self.to_append,
-            )
-        self.to_append = True
+            self._flush_file(df)
         self._cache.clear()
 
     @property
@@ -238,7 +239,9 @@ class WriteCache:
 
 
 def process_file(
-    sim_params: SimulationParams, mol_relaxations: List[Dict[str, Any]] = None
+    queue: multiprocessing.Queue,
+    sim_params: SimulationParams,
+    mol_relaxations: List[Dict[str, Any]] = None,
 ) -> Optional[pandas.DataFrame]:
     """Read a file and compute the dynamics quantities.
 
@@ -254,17 +257,12 @@ def process_file(
     """
     assert sim_params.infile is not None
 
-    mol = str(sim_params.molecule)
-    press = sim_params.pressure
-    temp = sim_params.temperature
-    group_name = f"{mol}_P{press:.2f}_T{temp:.2f}".replace(".", "")
-
+    set_filename_vars(sim_params.infile, sim_params)
     if sim_params.outfile is not None:
-        dataframes = WriteCache(sim_params.outfile, group_name, to_append=True)
+        dataframes = WriteCache(queue=queue)
     else:
-        dataframes = WriteCache(
-            sim_params.outfile, group_name, to_append=True, cache_multiplier=0
-        )
+        dataframes = WriteCache(queue=queue)
+
     keyframes: List[dynamics] = []
     relaxframes: List[relaxations] = []
     if sim_params.infile.suffix == ".gsd":
@@ -319,9 +317,7 @@ def process_file(
         )
         mol_relax["temperature"] = sim_params.temperature
         mol_relax["pressure"] = sim_params.pressure
-        mol_relax.to_hdf(
-            sim_params.outfile, "molecular_relaxations", format="table", to_append=True
-        )
+        queue.put(("molecular_relaxations", mol_relax))
         return None
 
     return dataframes.to_dataframe()

--- a/src/sdanalysis/threading.py
+++ b/src/sdanalysis/threading.py
@@ -1,0 +1,65 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © 2018 Malcolm Ramsay <malramsay64@gmail.com>
+#
+# Distributed under terms of the MIT license.
+
+"""Module to manage the multiprocessing capabilities of this package.
+
+This is segregated to make it simpler to remove, test and work on without affecting
+the rest of the implementation.
+
+"""
+from copy import deepcopy
+from multiprocessing import Manager, Pool, Queue
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pandas
+
+from .params import SimulationParams
+from .read import process_file
+
+
+def file_writer(queue: Queue, outfile: Path):
+    with pandas.HDFStore(outfile) as dst:
+        while True:
+            group, dataset = queue.get()
+            if dataset is None:
+                break
+            dst.append(group, dataset)
+        dst.flush()
+
+
+def _set_input_file(sim_params: SimulationParams, infile: str) -> SimulationParams:
+    with sim_params.temp_context(infile=infile):
+        return deepcopy(sim_params)
+
+
+def parallel_process_files(
+    input_files: Tuple[str],
+    sim_params: SimulationParams,
+    relaxations: List[Dict[str, Any]] = None,
+) -> None:
+    # The manager queue needs to be used
+    manager = Manager()
+    queue = manager.Queue()
+
+    with Pool() as pool:
+
+        # Put file writing process to work first
+        writer = pool.apply_async(file_writer, (queue, sim_params.outfile))
+
+        # Fire off worker processes
+        # starmap allows for passing multiple args to process_file
+        pool.starmap(
+            process_file,
+            ((queue, _set_input_file(sim_params, i), relaxations) for i in input_files),
+        )
+
+        # Send None to file writer to kill
+        queue.put(None)
+        # Wait for the file writer to finish writing
+        writer.wait()

--- a/src/sdanalysis/util.py
+++ b/src/sdanalysis/util.py
@@ -61,9 +61,12 @@ def get_filename_vars(fname: PathLike):
 def set_filename_vars(fname: PathLike, sim_params: SimulationParams) -> None:
     """Set the variables of the simulations params according to the filename."""
     var = get_filename_vars(fname)
-    sim_params.temperature = float(var.temperature)
-    sim_params.pressure = float(var.pressure)
-    sim_params.space_group = var.crystal
+    for attr in ["temperature", "pressure", "crystal"]:
+        if getattr(var, attr) is not None:
+            value = getattr(var, attr)
+            if attr not in ["crystal"]:
+                value = float(value)
+            setattr(sim_params, attr, value)
 
 
 def orientation2positions(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,6 +13,7 @@ import pytest
 from click.testing import CliRunner
 
 from sdanalysis import SimulationParams, molecules, read, relaxation
+from sdanalysis.threading import parallel_process_files
 
 MOLECULE_LIST = [
     molecules.Molecule,
@@ -38,9 +39,16 @@ def runner():
 @pytest.fixture()
 def dynamics_file():
     infile = Path(__file__).parent / "data/trajectory-Trimer-P13.50-T3.00.gsd"
-    with TemporaryDirectory() as tmp:
-        outfile = Path(tmp) / "dynamics.h5"
-        sim_params = SimulationParams(infile=infile, outfile=outfile, output=tmp)
-        read.process_file(sim_params)
+    with TemporaryDirectory() as output:
+        outfile = Path(output) / "dynamics.h5"
+        sim_params = SimulationParams(outfile=outfile, output=output)
+        parallel_process_files([infile], sim_params)
 
         yield outfile
+
+
+@pytest.fixture()
+def sim_params():
+    with TemporaryDirectory() as output:
+        params = SimulationParams(output=output)
+        yield params

--- a/test/integration_test.py
+++ b/test/integration_test.py
@@ -21,6 +21,15 @@ def trajectory():
     return Path(__file__).parent / "data/trajectory-Trimer-P13.50-T3.00.gsd"
 
 
+def test_dynamics_file(dynamics_file):
+    assert dynamics_file.is_file()
+    with pandas.HDFStore(dynamics_file) as src:
+        assert "/dynamics" in src.keys()
+        assert "/molecular_relaxations" in src.keys()
+        for key in src.keys():
+            assert "/dynamics/" not in src.keys()
+
+
 def test_runner_file(runner):
     import click
 

--- a/test/threading_test.py
+++ b/test/threading_test.py
@@ -1,0 +1,22 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © 2018 Malcolm Ramsay <malramsay64@gmail.com>
+#
+# Distributed under terms of the MIT license.
+
+from pathlib import Path
+
+from sdanalysis.threading import _set_input_file
+
+
+def test_set_input_file(sim_params):
+    infile = Path("test.in")
+    result_params = _set_input_file(sim_params, infile)
+    assert result_params.infile == infile
+    assert sim_params.infile != infile
+    init_temp = result_params.temperature
+    result_params.temperature = 0.1
+    assert sim_params.temperature == init_temp
+    assert result_params.temperature == 0.1


### PR DESCRIPTION
This uses the python multiprocessing module to process a collection of
files in parallel, while using an alternate thread to write the files.
There is no support for parallel writing of HDF5 files and alternate
methods don't work, so this is the only method of parallelism which will
work given the constraints I am working in.

It turns out that creating parallel threads for processing is rather
simple once the appropriate functions are set up.