### PR TITLE
Handle errors and weird data in relaxations

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,6 +62,7 @@ disable=bad-continuation,
         too-few-public-methods,
         unsubscriptable-object,
         not-an-iterable,
+        no-value-for-parameter,
 
 [REPORTS]
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ setup:
 
 test:
 	python3 -m isort --check-only --recursive src/
+	python3 -m isort --check-only --recursive test/
 	python3 -m black --check src/
+	python3 -m black --check test/
 	python3 -m pylint src/
 	python3 -m mypy src/
 	python3 -m pytest

--- a/src/sdanalysis/relaxation.py
+++ b/src/sdanalysis/relaxation.py
@@ -24,10 +24,26 @@ logger = logging.getLogger(__name__)
 
 
 def _msd_function(x: np.ndarray, m: float, b: float) -> np.ndarray:
+    """Function to fit the mean squared displacement.
+
+    The relaxation value of the mean squared displacement (MSD) is found by fitting the line
+
+    .. math::
+        y = mx + b
+
+    with the relaxation value, i.e. the Diffusion constant, being proportional to :math:`m`.
+
+    """
     return m * x + b
 
 
 def _exponential_decay(x: np.ndarray, a: float, b: float, c: float = 0) -> np.ndarray:
+    """Function used to fit an exponential decay.
+
+    This is is the functional form used to fit a function which exhibits exponential
+    decay. The important parameter here is :math:`b`, which is the rate of the decay.
+
+    """
     return a * np.exp(-b * x) + c
 
 
@@ -35,12 +51,34 @@ def _exponential_decay(x: np.ndarray, a: float, b: float, c: float = 0) -> np.nd
 def _ddx_exponential_decay(
     x: np.ndarray, a: float, b: float, c: float = 0
 ) -> np.ndarray:
+    """The first derivative of the exponential decay function.
+
+    This is the analytical first derivative of the function used for the fit of the
+    exponential decay. This is used to speed up the root finding step.
+
+    .. note:
+
+        This function needs to have the same input arguments as the function it is a
+        derivative of.
+
+    """
     return -b * a * np.exp(-b * x)
 
 
 def _d2dx2_exponential_decay(
     x: np.ndarray, a: float, b: float, c: float = 0
 ) -> np.ndarray:
+    """The first derivative of the exponential decay function.
+
+    This is the analytical first derivative of the function used for the fit of the
+    exponential decay. This is used to speed up the root finding step.
+
+    .. note:
+
+        This function needs to have the same input arguments as the function it is a
+        derivative of.
+
+    """
     return b * b * a * np.exp(-b * x)
 
 

--- a/src/sdanalysis/relaxation.py
+++ b/src/sdanalysis/relaxation.py
@@ -114,13 +114,13 @@ def diffusion_constant(time: np.ndarray, msd: np.ndarray) -> Result:
         linear_region = np.logical_and(msd > 2, msd < 100)
     except FloatingPointError as err:
         logger.exception("%s", err)
-        return Result(0, 0)
+        return Result(np.nan, np.nan)
     try:
         popt, pcov = curve_fit(_msd_function, time[linear_region], msd[linear_region])
     except TypeError as err:
         logger.debug("time: %s", time[linear_region])
         logger.exception("%s", err)
-        return Result(0, 0)
+        return Result(np.nan, np.nan)
 
     perr = 2 * np.sqrt(np.diag(pcov))
     return Result(popt[0], perr[0])

--- a/test/relaxation_test.py
+++ b/test/relaxation_test.py
@@ -132,7 +132,6 @@ def test_compute_relaxations_values(dynamics_file):
         assert df[col].dtype == float
 
 
-@settings(max_examples=100)
 @given(values=arrays(dtype=np.float32, shape=1000))
 @pytest.mark.parametrize("relax_type", relaxation_types)
 def test_compute_relaxations_random(values, relax_type):
@@ -140,7 +139,6 @@ def test_compute_relaxations_random(values, relax_type):
     relaxation.compute_relaxation_value(timesteps, values, relax_type)
 
 
-@settings(max_examples=100)
 @given(values=arrays(dtype=np.float32, shape=1000))
 @pytest.mark.parametrize("relax_type", relaxation_types)
 def test_series_relaxations_random(values, relax_type):

--- a/test/relaxation_test.py
+++ b/test/relaxation_test.py
@@ -133,24 +133,18 @@ def test_compute_relaxations_values(dynamics_file):
 
 
 @settings(max_examples=100)
-@given(
-    timesteps=arrays(dtype=np.uint32, shape=1000),
-    values=arrays(dtype=np.float32, shape=1000),
-)
+@given(values=arrays(dtype=np.float32, shape=1000))
 @pytest.mark.parametrize("relax_type", relaxation_types)
-def test_compute_relaxations_random(timesteps, values, relax_type):
-    timesteps.sort()
+def test_compute_relaxations_random(values, relax_type):
+    timesteps = np.arange(values.shape[0], dtype=int)
     relaxation.compute_relaxation_value(timesteps, values, relax_type)
 
 
 @settings(max_examples=100)
-@given(
-    timesteps=arrays(dtype=np.uint32, shape=1000),
-    values=arrays(dtype=np.float32, shape=1000),
-)
+@given(values=arrays(dtype=np.float32, shape=1000))
 @pytest.mark.parametrize("relax_type", relaxation_types)
-def test_series_relaxations_random(timesteps, values, relax_type):
-    timesteps.sort()
+def test_series_relaxations_random(values, relax_type):
+    timesteps = np.arange(values.shape[0], dtype=int)
     s = pandas.Series(data=values, index=timesteps, name=relax_type)
     relaxation.series_relaxation_value(s)
 


### PR DESCRIPTION
The calculation of the relaxation quantities was only configured to handle
the case of optimal data being passed to it. This commit uses hypothesis to
fuzz test the functions, along with patching all the issues that arose from
the non-optimal data being thrown at the functions.

Fixes #46