### PR TITLE
Error handling in interactive Configuration

### DIFF
--- a/src/sdanalysis/figures/interactive_config.py
+++ b/src/sdanalysis/figures/interactive_config.py
@@ -143,7 +143,6 @@ class TrimerFigure(object):
             width=self.controls_width,
         )
 
-
         self._pressure_button.on_change("active", self.update_current_trajectory)
         self._temperature_button.on_change("active", self.update_current_trajectory)
 
@@ -165,21 +164,19 @@ class TrimerFigure(object):
     def get_selected_variables(self) -> variables:
         try:
             temperature = self.variable_selection["temperature"][
-                    self._temperature_button.active
-                ]
+                self._temperature_button.active
+            ]
         except IndexError:
             temperature = None
 
         try:
-            pressure=self.variable_selection["pressure"][self._pressure_button.active]
+            pressure = self.variable_selection["pressure"][self._pressure_button.active]
         except IndexError:
             pressure = None
 
         crystal = None
 
-        return variables(
-            temperature, pressure, crystal
-        )
+        return variables(temperature, pressure, crystal)
 
     def get_selected_file(self) -> Path:
         return variables_to_file(self.get_selected_variables(), self.directory)

--- a/src/sdanalysis/figures/interactive_config.py
+++ b/src/sdanalysis/figures/interactive_config.py
@@ -73,7 +73,7 @@ def parse_directory(directory: Path, glob: str = "dump*.gsd") -> Dict[str, List]
     return all_values
 
 
-def variables_to_file(file_vars: variables, directory: Path) -> Path:
+def variables_to_file(file_vars: variables, directory: Path) -> Optional[Path]:
     if file_vars.crystal is not None:
         glob_pattern = f"dump-Trimer-P{file_vars.pressure}-T{file_vars.temperature}-{file_vars.crystal}.gsd"
     else:
@@ -178,7 +178,7 @@ class TrimerFigure(object):
 
         return variables(temperature, pressure, crystal)
 
-    def get_selected_file(self) -> Path:
+    def get_selected_file(self) -> Optional[Path]:
         return variables_to_file(self.get_selected_variables(), self.directory)
 
     def update_frame(self, attr, old, new) -> None:


### PR DESCRIPTION
Ensure that the interactive configuration explorer either provides useful information
upon finding errors or handles it quietly (with a preference for the previous).

Fixes: #66