### PR TITLE
fix: Ignore import outside toplevel for main

### DIFF
--- a/src/sdanalysis/main.py
+++ b/src/sdanalysis/main.py
@@ -212,11 +212,14 @@ def _interactive_verbosity(_, __, value) -> None:
 )
 def figure(ip, directory, model) -> None:
     """Start bokeh server with the file passed."""
+    # pylint disable=import-outside-toplevel
     from bokeh.server.server import Server
     from bokeh.application import Application
     from bokeh.application.handlers.function import FunctionHandler
 
     from .figures.interactive_config import make_document
+
+    # pylint enable=import-outside-toplevel
 
     if isinstance(ip, str):
         ip = (ip,)


### PR DESCRIPTION
This only imports the bokeh applications for the figures subcommand.